### PR TITLE
Features/GM-07: Envío de correos

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CoreModule } from './core/core.module';
 import { LoginModule } from './login/login.module';
-import { registerLocaleData } from '@angular/common';
+import { DatePipe, registerLocaleData } from '@angular/common';
 import localeEs from '@angular/common/locales/es';
 import { EvidencesModule } from './evidences/evidences.module';
 
@@ -25,7 +25,9 @@ registerLocaleData(localeEs,'es');
     EvidencesModule
 
   ],
-  providers: [],
+  providers: [
+    DatePipe
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/evidences/evidences.module.ts
+++ b/src/app/evidences/evidences.module.ts
@@ -12,11 +12,15 @@ import { MessageModule } from 'primeng/message';
 import { ToastModule } from 'primeng/toast';
 import { HttpClientModule } from '@angular/common/http';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { EvidenceEmailComponent } from './views/evidence-email/evidence-email.component';
+import { DropdownModule } from 'primeng/dropdown';
+import { CalendarModule } from 'primeng/calendar';
 
 @NgModule({
   declarations: [
     EvidenceListComponent,
-    EvidenceUploadComponent
+    EvidenceUploadComponent,
+    EvidenceEmailComponent
   ],
   imports: [
     CommonModule,
@@ -29,6 +33,8 @@ import { ProgressSpinnerModule } from 'primeng/progressspinner';
     MessageModule,
     ToastModule,
     ProgressSpinnerModule,
+    DropdownModule,
+    CalendarModule,
     HttpClientModule
   ]
 })

--- a/src/app/evidences/models/Center.ts
+++ b/src/app/evidences/models/Center.ts
@@ -1,3 +1,6 @@
+/**
+ * Center: clase para manejo de datos de centros.
+ */
 export class Center {
     id: number;
     name: String;

--- a/src/app/evidences/models/Center.ts
+++ b/src/app/evidences/models/Center.ts
@@ -1,4 +1,8 @@
-export class Center{
+export class Center {
     id: number;
     name: String;
+
+    public constructor(init?: Partial<Center>) {
+        Object.assign(this, init);
+    }
 }

--- a/src/app/evidences/models/Center.ts
+++ b/src/app/evidences/models/Center.ts
@@ -1,0 +1,4 @@
+export class Center{
+    id: number;
+    name: String;
+}

--- a/src/app/evidences/models/Reminder.ts
+++ b/src/app/evidences/models/Reminder.ts
@@ -1,0 +1,7 @@
+/**
+ * Reminder: clase para manejo de datos de petición para recordatorios por email.
+ */
+export class Reminder {
+    closingDate: Date;
+    centerId: number;
+}

--- a/src/app/evidences/services/center.service.spec.ts
+++ b/src/app/evidences/services/center.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CenterService } from './center.service';
+
+describe('CenterService', () => {
+  let service: CenterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CenterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/evidences/services/center.service.spec.ts
+++ b/src/app/evidences/services/center.service.spec.ts
@@ -1,7 +1,9 @@
+/**
+ * Tests para CenterService.
+ */
+
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { environment } from 'src/environments/environment';
-import { Center } from '../models/Center';
 
 import { CenterService } from './center.service';
 

--- a/src/app/evidences/services/center.service.spec.ts
+++ b/src/app/evidences/services/center.service.spec.ts
@@ -1,16 +1,29 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { environment } from 'src/environments/environment';
+import { Center } from '../models/Center';
 
 import { CenterService } from './center.service';
 
 describe('CenterService', () => {
   let service: CenterService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ]
+    });
     service = TestBed.inject(CenterService);
+    http = TestBed.inject(HttpTestingController);
   });
 
+  /**
+   * Servicio debería crearse.
+   */
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
 });

--- a/src/app/evidences/services/center.service.ts
+++ b/src/app/evidences/services/center.service.ts
@@ -11,8 +11,6 @@ export class CenterService {
 
   /**
    * Constructor: inicializa servicio HttpClient para comunicación con backend.
-   * 
-   TODO DOCS
    */
   constructor(
     private http: HttpClient

--- a/src/app/evidences/services/center.service.ts
+++ b/src/app/evidences/services/center.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { Center } from '../models/Center';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CenterService {
+
+  /**
+   * Constructor: inicializa servicio HttpClient para comunicación con backend.
+   * 
+   TODO DOCS
+   */
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  /**
+  * GET: Obtener todos los centros de la base de datos.
+  * @returns Listado de Center
+  */
+  getCenters(): Observable<Center[]> {
+    return this.http.get<Center[]>(environment.server + "/center");
+  }
+}

--- a/src/app/evidences/services/center.service.ts
+++ b/src/app/evidences/services/center.service.ts
@@ -4,6 +4,9 @@ import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Center } from '../models/Center';
 
+/**
+ * Servicio de datos de centros
+ */
 @Injectable({
   providedIn: 'root'
 })

--- a/src/app/evidences/services/email.service.spec.ts
+++ b/src/app/evidences/services/email.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EmailService } from './email.service';
+
+describe('EmailService', () => {
+  let service: EmailService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EmailService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/evidences/services/email.service.spec.ts
+++ b/src/app/evidences/services/email.service.spec.ts
@@ -5,6 +5,8 @@
 import { DatePipe } from '@angular/common';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { environment } from 'src/environments/environment';
+import { Reminder } from '../models/Reminder';
 
 import { EmailService } from './email.service';
 
@@ -38,10 +40,11 @@ describe('EmailService', () => {
   it('should return error on invalid data', () => {
     let ok: boolean;
 
-    let closingDate = new Date("2020-12-09");
-    let centerId = 3;
+    let reminder = new Reminder();
+    reminder.closingDate = new Date("2020-12-09");
+    reminder.centerId = 3;
 
-    service.sendEmails(closingDate, centerId).subscribe({
+    service.sendEmails(reminder).subscribe({
       next: result => {
         ok = true;
         expect(result).toBeFalsy();
@@ -54,16 +57,15 @@ describe('EmailService', () => {
 
     http.expectOne({
       method: 'POST',
-      url: service.composeUrl(closingDate, centerId),
+      url: environment.server + "/email/sendReminders"
     }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
 
     expect(ok).toBeFalse();
 
+    reminder.closingDate = new Date("2022-12-09");
+    reminder.centerId = 0;
 
-    closingDate = new Date("2022-12-09");
-    centerId = 0;
-
-    service.sendEmails(closingDate, centerId).subscribe({
+    service.sendEmails(reminder).subscribe({
       next: result => {
         ok = true;
         expect(result).toBeFalsy();
@@ -76,16 +78,15 @@ describe('EmailService', () => {
 
     http.expectOne({
       method: 'POST',
-      url: service.composeUrl(closingDate, centerId),
+      url: environment.server + "/email/sendReminders"
     }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
 
     expect(ok).toBeFalse();
 
+    reminder.closingDate = new Date("2020-12-09");
+    reminder.centerId = 0;
 
-    closingDate = new Date("2020-12-09");
-    centerId = 0;
-
-    service.sendEmails(closingDate, centerId).subscribe({
+    service.sendEmails(reminder).subscribe({
       next: result => {
         ok = true;
         expect(result).toBeFalsy();
@@ -98,7 +99,7 @@ describe('EmailService', () => {
 
     http.expectOne({
       method: 'POST',
-      url: service.composeUrl(closingDate, centerId),
+      url: environment.server + "/email/sendReminders"
     }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
 
     expect(ok).toBeFalse();
@@ -110,10 +111,11 @@ describe('EmailService', () => {
   it('should return ok on valid data', () => {
     let ok: boolean;
 
-    let closingDate = new Date("2022-12-09");
-    let centerId = 3;
+    let reminder = new Reminder();
+    reminder.closingDate = new Date("2022-12-09");
+    reminder.centerId = 3;
 
-    service.sendEmails(closingDate, centerId).subscribe({
+    service.sendEmails(reminder).subscribe({
       next: result => {
         ok = true;
         expect(result).toBeFalsy();
@@ -126,7 +128,7 @@ describe('EmailService', () => {
 
     http.expectOne({
       method: 'POST',
-      url: service.composeUrl(closingDate, centerId),
+      url: environment.server + "/email/sendReminders"
     }).flush(null, { status: 200, statusText: 'OK' });
 
     expect(ok).toBeTrue();

--- a/src/app/evidences/services/email.service.spec.ts
+++ b/src/app/evidences/services/email.service.spec.ts
@@ -1,16 +1,131 @@
+import { DatePipe } from '@angular/common';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { environment } from 'src/environments/environment';
 
 import { EmailService } from './email.service';
 
 describe('EmailService', () => {
   let service: EmailService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        DatePipe
+      ]
+    });
     service = TestBed.inject(EmailService);
+    http = TestBed.inject(HttpTestingController);
   });
 
+  /**
+   * Servicio debería crearse.
+   */
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  /**
+   *  Servicio debería devolver error con parámetros incorrectos.
+   */
+  it('should return error on invalid data', () => {
+    let ok: boolean;
+
+    let closingDate = new Date("2020-12-09");
+    let centerId = 3;
+
+    service.sendEmails(closingDate, centerId).subscribe({
+      next: result => {
+        ok = true;
+        expect(result).toBeFalsy();
+      },
+      error: error => {
+        ok = false;
+        expect(error).toBeTruthy();
+      }
+    });
+
+    http.expectOne({
+      method: 'POST',
+      url: service.composeUrl(closingDate, centerId),
+    }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
+
+    expect(ok).toBeFalse();
+
+
+    closingDate = new Date("2022-12-09");
+    centerId = 0;
+
+    service.sendEmails(closingDate, centerId).subscribe({
+      next: result => {
+        ok = true;
+        expect(result).toBeFalsy();
+      },
+      error: error => {
+        ok = false;
+        expect(error).toBeTruthy();
+      }
+    });
+
+    http.expectOne({
+      method: 'POST',
+      url: service.composeUrl(closingDate, centerId),
+    }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
+
+    expect(ok).toBeFalse();
+
+
+    closingDate = new Date("2020-12-09");
+    centerId = 0;
+
+    service.sendEmails(closingDate, centerId).subscribe({
+      next: result => {
+        ok = true;
+        expect(result).toBeFalsy();
+      },
+      error: error => {
+        ok = false;
+        expect(error).toBeTruthy();
+      }
+    });
+
+    http.expectOne({
+      method: 'POST',
+      url: service.composeUrl(closingDate, centerId),
+    }).flush(null, { status: 400, statusText: 'BAD REQUEST' });
+
+    expect(ok).toBeFalse();
+  });
+
+  /**
+   *  Servicio debería funcionar con datos correctos.
+   */
+  it('should return ok on valid data', () => {
+    let ok: boolean;
+
+    let closingDate = new Date("2022-12-09");
+    let centerId = 3;
+
+    service.sendEmails(closingDate, centerId).subscribe({
+      next: result => {
+        ok = true;
+        expect(result).toBeFalsy();
+      },
+      error: error => {
+        ok = false;
+        expect(error).toBeFalsy();
+      }
+    });
+
+    http.expectOne({
+      method: 'POST',
+      url: service.composeUrl(closingDate, centerId),
+    }).flush(null, { status: 200, statusText: 'OK' });
+
+    expect(ok).toBeTrue();
   });
 });

--- a/src/app/evidences/services/email.service.spec.ts
+++ b/src/app/evidences/services/email.service.spec.ts
@@ -1,7 +1,10 @@
+/**
+ * Tests para EmailService.
+ */
+
 import { DatePipe } from '@angular/common';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { environment } from 'src/environments/environment';
 
 import { EmailService } from './email.service';
 

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -2,9 +2,11 @@ import { DatePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Center } from 'src/app/evidences/models/Center';
 import { environment } from 'src/environments/environment';
 
+/**
+ * Servicio de datos de envío de correos electrónicos
+ */
 @Injectable({
   providedIn: 'root'
 })

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { Reminder } from '../models/Reminder';
 
 /**
  * Servicio de datos de envío de correos electrónicos
@@ -25,22 +26,10 @@ export class EmailService {
   /** 
    * POST: enviar fecha de cierre e ID de centro a backend para procesar y enviar los correos electrónicos de esa geografía.
    * 
-   * @param closingDate Fecha de cierre
-   * @param centerId ID del centro por el que filtrar
+   * @param reminder Objeto Reminder con fecha de cierre e ID de centro para procesado de correos electrónicos.
    */
-  sendEmails(closingDate: Date, centerId: number): Observable<any> {
-    return this.http.post<any>(this.composeUrl(closingDate, centerId), null);
+  sendEmails(reminder: Reminder): Observable<any> {
+    return this.http.post<any>(environment.server + "/email/sendReminders", reminder);
   }
 
-  /**
-  * Componer parámetros de URL dada una fecha de cierre e ID de centro.
-  * 
-  * @param closingDate Fecha de cierre
-  * @param centerId ID del centro por el que filtrar
-  */
-  composeUrl(closingDate: Date, centerId: number) {
-    let url = environment.server + "/email/sendReminders";
-    let params = "closingDate=" + this.pipe.transform(closingDate, "yyyy-MM-dd") + "&" + "centerId=" + centerId;
-    return url + "?" + params;
-  }
 }

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -1,0 +1,36 @@
+import { DatePipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Center } from 'src/app/evidences/models/Center';
+import { environment } from 'src/environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmailService {
+
+  /**
+   * Constructor: inicializa servicio HttpClient para comunicación con backend.
+   * 
+   TODO DOCS
+   */
+  constructor(
+    private http: HttpClient,
+    private pipe: DatePipe
+  ) { }
+
+  /** TODO DOCS */
+  sendEmails(closingDate: Date, centerId: number): Observable<any> {
+    return this.http.post<any>(this.composeFindUrl(closingDate, centerId), null);
+  }
+
+  /**
+  * TODO DOCS
+  */
+  private composeFindUrl(closingDate: Date, centerId: number) {
+    let url = environment.server + "/email/send";
+    let params = "closingDate=" + this.pipe.transform(closingDate, "yyyy-MM-dd") + "&" + "centerId=" + centerId;
+    return url + "?" + params;
+  }
+}

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -29,7 +29,7 @@ export class EmailService {
   * TODO DOCS
   */
   private composeFindUrl(closingDate: Date, centerId: number) {
-    let url = environment.server + "/email/send";
+    let url = environment.server + "/email/sendReminders";
     let params = "closingDate=" + this.pipe.transform(closingDate, "yyyy-MM-dd") + "&" + "centerId=" + centerId;
     return url + "?" + params;
   }

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -13,22 +13,24 @@ export class EmailService {
   /**
    * Constructor: inicializa servicio HttpClient para comunicación con backend.
    * 
-   TODO DOCS
+   * Incluye DatePipe para procesamiento de fechas.
    */
   constructor(
     private http: HttpClient,
     private pipe: DatePipe
   ) { }
 
-  /** TODO DOCS */
+  /** 
+   * POST: enviar fecha de cierre e ID de centro a backend para procesar y enviar los correos electrónicos de esa geografía.
+   */
   sendEmails(closingDate: Date, centerId: number): Observable<any> {
-    return this.http.post<any>(this.composeFindUrl(closingDate, centerId), null);
+    return this.http.post<any>(this.composeUrl(closingDate, centerId), null);
   }
 
   /**
-  * TODO DOCS
+  * Componer parámetros de URL dada una fecha de cierre e ID de centro.
   */
-  private composeFindUrl(closingDate: Date, centerId: number) {
+  composeUrl(closingDate: Date, centerId: number) {
     let url = environment.server + "/email/sendReminders";
     let params = "closingDate=" + this.pipe.transform(closingDate, "yyyy-MM-dd") + "&" + "centerId=" + centerId;
     return url + "?" + params;

--- a/src/app/evidences/services/email.service.ts
+++ b/src/app/evidences/services/email.service.ts
@@ -24,6 +24,9 @@ export class EmailService {
 
   /** 
    * POST: enviar fecha de cierre e ID de centro a backend para procesar y enviar los correos electrónicos de esa geografía.
+   * 
+   * @param closingDate Fecha de cierre
+   * @param centerId ID del centro por el que filtrar
    */
   sendEmails(closingDate: Date, centerId: number): Observable<any> {
     return this.http.post<any>(this.composeUrl(closingDate, centerId), null);
@@ -31,6 +34,9 @@ export class EmailService {
 
   /**
   * Componer parámetros de URL dada una fecha de cierre e ID de centro.
+  * 
+  * @param closingDate Fecha de cierre
+  * @param centerId ID del centro por el que filtrar
   */
   composeUrl(closingDate: Date, centerId: number) {
     let url = environment.server + "/email/sendReminders";

--- a/src/app/evidences/views/evidence-email/evidence-email.component.html
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.html
@@ -1,0 +1,25 @@
+<!-- Sección contenido -->
+<div class="flex flex-column mb-5">
+    <p>Geografía:</p>
+    <p-dropdown appendTo="body" [options]="centers" [(ngModel)]="center" optionLabel="name"
+        placeholder="Seleccione centro" [filter]="true" filterBy="name" [disabled]="this.isLoading">
+    </p-dropdown>
+
+    <p class="mt-3">Fecha de cierre:</p>
+    <p-calendar appendTo="body" [(ngModel)]="closingDate" dateFormat="dd/mm/yy" [disabled]="this.isLoading">
+    </p-calendar>
+</div>
+
+<!-- Sección botones de acción -->
+<div class="flex justify-content-end gap-3">
+    <button pButton label="Cancelar" class="p-button-secondary" (click)="onCancel()"
+        [disabled]="this.isLoading"></button>
+    <button pButton label="Enviar" class="p-button-primary" (click)="onSend()"
+        [disabled]="this.center == null || this.closingDate == null ||this.isLoading"></button>
+</div>
+
+<!-- Mostrar animación en proceso de carga -->
+<div class="absolute m-auto right-0 left-0 top-0 bottom-0 bg-white-alpha-50 flex align-self-center align-items-center flex-column justify-content-center"
+    *ngIf="isLoading">
+    <p-progressSpinner></p-progressSpinner>
+</div>

--- a/src/app/evidences/views/evidence-email/evidence-email.component.html
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.html
@@ -1,12 +1,12 @@
 <!-- Sección contenido -->
 <div class="flex flex-column mb-5">
     <p>Geografía:</p>
-    <p-dropdown appendTo="body" [options]="centers" [(ngModel)]="center" optionLabel="name"
+    <p-dropdown styleClass="w-full" ngDefaultControl appendTo="body" [options]="centers" [(ngModel)]="center" optionLabel="name"
         placeholder="Seleccione centro" [filter]="true" filterBy="name" [disabled]="this.isLoading">
     </p-dropdown>
 
     <p class="mt-3">Fecha de cierre:</p>
-    <p-calendar appendTo="body" [(ngModel)]="closingDate" dateFormat="dd/mm/yy" [disabled]="this.isLoading">
+    <p-calendar styleClass="w-full" ngDefaultControl appendTo="body" [(ngModel)]="closingDate" dateFormat="dd/mm/yy" firstDayOfWeek="1" [disabled]="this.isLoading">
     </p-calendar>
 </div>
 
@@ -15,7 +15,7 @@
     <button pButton label="Cancelar" class="p-button-secondary" (click)="onCancel()"
         [disabled]="this.isLoading"></button>
     <button pButton label="Enviar" class="p-button-primary" (click)="onSend()"
-        [disabled]="this.center == null || this.closingDate == null ||this.isLoading"></button>
+        [disabled]="this.center == null || this.closingDate == null || this.isLoading"></button>
 </div>
 
 <!-- Mostrar animación en proceso de carga -->

--- a/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
@@ -1,4 +1,20 @@
+/**
+ * Tests para EvidenceEmail.
+ */
+
+import { DatePipe } from '@angular/common';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { DynamicDialogConfig, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { ToastModule } from 'primeng/toast';
+import { of } from 'rxjs';
+import { SnackbarService } from 'src/app/core/services/snackbar.service';
+import { Center } from '../../models/Center';
+import { CenterService } from '../../services/center.service';
+import { EmailService } from '../../services/email.service';
 
 import { EvidenceEmailComponent } from './evidence-email.component';
 
@@ -6,11 +22,44 @@ describe('EvidenceEmailComponent', () => {
   let component: EvidenceEmailComponent;
   let fixture: ComponentFixture<EvidenceEmailComponent>;
 
+  let mockEmailService;
+  let mockCenterService;
+  let http: HttpTestingController;
+
+  let centerList = [
+    new Center({ id: 1, name: 'Madrid' }),
+    new Center({ id: 2, name: 'Barcelona' }),
+    new Center({ id: 3, name: 'Valencia' })
+  ];
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ EvidenceEmailComponent ]
+      declarations: [
+        EvidenceEmailComponent
+      ],
+      imports: [
+        HttpClientTestingModule,
+        ButtonModule,
+        DynamicDialogModule,
+        FormsModule,
+        ToastModule
+      ],
+      providers: [
+        EmailService,
+        CenterService,
+        DynamicDialogRef,
+        DynamicDialogConfig,
+        SnackbarService,
+        MessageService,
+        DatePipe
+      ]
     })
-    .compileComponents();
+      .compileComponents();
+
+    mockEmailService = jasmine.createSpyObj("EmailService", ["sendEmails", "composeUrl"]);
+    mockCenterService = jasmine.createSpyObj("CenterService", ["getCenters"]);
+    fixture = TestBed.createComponent(EvidenceEmailComponent);
+    http = TestBed.inject(HttpTestingController);
   });
 
   beforeEach(() => {
@@ -19,7 +68,48 @@ describe('EvidenceEmailComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  /**
+   * Componente debería enviar datos válidos.
+   */
+  it('should send emails on valid data', () => {
+    let spyClose = spyOn(component, "close");
+    mockCenterService.getCenters.and.returnValue(of(centerList));
+    component.isLoading = false;
+
+    component.closingDate = new Date("2022-12-09");
+    component.center = centerList[2];
+
+    expect(component.isLoading).toBe(false);
+
+    component.onSend();
+
+    fixture.detectChanges();
+    expect(component.isLoading).toBe(true);
+
+    http.expectOne({
+      method: 'POST',
+      url: mockEmailService.composeUrl(component.closingDate, component.center.id)
+    }).flush(null, { status: 200, statusText: 'OK' });
+
+    fixture.detectChanges();
+    expect(component.isLoading).toBe(false);
+
+    mockEmailService.sendEmails(component.closingDate, component.center.id);
+
+    expect(mockEmailService.sendEmails).toHaveBeenCalledWith(component.closingDate, component.center.id);
+    expect(spyClose).toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(component.isLoading).toBe(false);
+  });
+
+  /**
+   * Componente debería cerrarse al cancelar.
+   */
+  it('should close on cancel', () => {
+    let spyClose = spyOn(component, "close");
+    component.onCancel();
+
+    expect(spyClose).toHaveBeenCalled();
   });
 });

--- a/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
@@ -12,7 +12,9 @@ import { DynamicDialogConfig, DynamicDialogModule, DynamicDialogRef } from 'prim
 import { ToastModule } from 'primeng/toast';
 import { of } from 'rxjs';
 import { SnackbarService } from 'src/app/core/services/snackbar.service';
+import { environment } from 'src/environments/environment';
 import { Center } from '../../models/Center';
+import { Reminder } from '../../models/Reminder';
 import { CenterService } from '../../services/center.service';
 import { EmailService } from '../../services/email.service';
 
@@ -56,7 +58,7 @@ describe('EvidenceEmailComponent', () => {
     })
       .compileComponents();
 
-    mockEmailService = jasmine.createSpyObj("EmailService", ["sendEmails", "composeUrl"]);
+    mockEmailService = jasmine.createSpyObj("EmailService", ["sendEmails"]);
     mockCenterService = jasmine.createSpyObj("CenterService", ["getCenters"]);
     fixture = TestBed.createComponent(EvidenceEmailComponent);
     http = TestBed.inject(HttpTestingController);
@@ -86,10 +88,14 @@ describe('EvidenceEmailComponent', () => {
     fixture.detectChanges();
     expect(component.isLoading).toBe(true);
 
+    let reminder = new Reminder();
+    reminder.closingDate = component.closingDate;
+    reminder.centerId = component.center.id;
+
     http.expectOne({
       method: 'POST',
-      url: mockEmailService.composeUrl(component.closingDate, component.center.id)
-    }).flush(null, { status: 200, statusText: 'OK' });
+      url: environment.server + "/email/sendReminders"
+    }).flush(reminder, { status: 200, statusText: 'OK' });
 
     fixture.detectChanges();
     expect(component.isLoading).toBe(false);

--- a/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EvidenceEmailComponent } from './evidence-email.component';
+
+describe('EvidenceEmailComponent', () => {
+  let component: EvidenceEmailComponent;
+  let fixture: ComponentFixture<EvidenceEmailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EvidenceEmailComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EvidenceEmailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -3,10 +3,11 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { Center } from 'src/app/evidences/models/Center';
 import { SnackbarService } from 'src/app/core/services/snackbar.service';
 import { EmailService } from '../../services/email.service';
-import { DropdownModule } from 'primeng/dropdown';
 import { CenterService } from '../../services/center.service';
-import { CalendarModule } from 'primeng/calendar';
 
+/**
+ * EvidenceEmailComponent: TODO
+ */
 @Component({
   selector: 'app-evidence-email',
   templateUrl: './evidence-email.component.html',
@@ -20,6 +21,15 @@ export class EvidenceEmailComponent implements OnInit {
   center: Center;
   isLoading: boolean;
 
+  /**
+   * Constructor: inicializar servicios.
+   * 
+   * @param emailService 
+   * @param centerService 
+   * @param dialogRef 
+   * @param config 
+   * @param snackbarService 
+   */
   constructor(
     public emailService: EmailService,
     public centerService: CenterService,
@@ -28,6 +38,9 @@ export class EvidenceEmailComponent implements OnInit {
     private snackbarService: SnackbarService
   ) { }
 
+  /**
+   * Obtener listado de centros al inicializar.
+   */
   ngOnInit(): void {
     this.isLoading = true;
     this.centerService.getCenters().subscribe({
@@ -43,6 +56,9 @@ export class EvidenceEmailComponent implements OnInit {
     );
   }
 
+  /**
+   * En caso de pulsar botón enviar, realizar petición a backend para enviar recordatorios.
+   */
   onSend() {
     this.isLoading = true;
     this.emailService.sendEmails(this.closingDate, this.center.id).subscribe({

--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -24,11 +24,11 @@ export class EvidenceEmailComponent implements OnInit {
   /**
    * Constructor: inicializar servicios.
    * 
-   * @param emailService 
-   * @param centerService 
-   * @param dialogRef 
-   * @param config 
-   * @param snackbarService 
+   * @param emailService Servicio EmailService para envío de datos a backend
+   * @param centerService Servicio Center service para obtención de centros desde backend
+   * @param dialogRef DynamicDialogRef, referencia al diálogo de la ventana Email
+   * @param config DynamicDialogCongig, configuración del diálogo de la ventana Email
+   * @param snackbarService Servicio SnackbarService para muestra de notificaciones o avisos en pantalla
    */
   constructor(
     public emailService: EmailService,

--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -4,6 +4,7 @@ import { Center } from 'src/app/evidences/models/Center';
 import { SnackbarService } from 'src/app/core/services/snackbar.service';
 import { EmailService } from '../../services/email.service';
 import { CenterService } from '../../services/center.service';
+import { Reminder } from '../../models/Reminder';
 
 /**
  * Componente EvidenceEmail: diálogo de selección de geografía y fecha de cierre para envío de correos electrónicos recordatorios desde la aplicación.
@@ -66,7 +67,12 @@ export class EvidenceEmailComponent implements OnInit {
    */
   onSend() {
     this.isLoading = true;
-    this.emailService.sendEmails(this.closingDate, this.center.id).subscribe({
+
+    let reminder = new Reminder();
+    reminder.closingDate = this.closingDate;
+    reminder.centerId = this.center.id;
+
+    this.emailService.sendEmails(reminder).subscribe({
       next: result => {
         if (result)
           this.snackbarService.showMessage("Recordatorios enviados. " + result);

--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -6,7 +6,7 @@ import { EmailService } from '../../services/email.service';
 import { CenterService } from '../../services/center.service';
 
 /**
- * EvidenceEmailComponent: TODO
+ * Componente EvidenceEmail: diálogo de selección de geografía y fecha de cierre para envío de correos electrónicos recordatorios desde la aplicación.
  */
 @Component({
   selector: 'app-evidence-email',
@@ -44,20 +44,25 @@ export class EvidenceEmailComponent implements OnInit {
   ngOnInit(): void {
     this.isLoading = true;
     this.centerService.getCenters().subscribe({
-     next:  centers => {
+      next: centers => {
         this.centers = centers;
         this.isLoading = false;
       },
       error: error => {
         this.snackbarService.error("Error obteniendo lista de centros. " + error);
         this.isLoading = false;
+        this.close();
       }
     }
     );
   }
 
   /**
-   * En caso de pulsar botón enviar, realizar petición a backend para enviar recordatorios.
+   * En caso de pulsar botón enviar, realizar petición a backend para enviar recordatorios a través de EmailService.
+   * 
+   * Se habilita la animación de carga hasta recibir una respuesta de backend.
+   * Se muestra un mensaje en pantalla en caso de producirse un fallo durante el envío de mensajes.
+   * Este método no se ejecutará si no se ha seleccionado un centro y fecha de cierre.
    */
   onSend() {
     this.isLoading = true;

--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnInit } from '@angular/core';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Center } from 'src/app/evidences/models/Center';
+import { SnackbarService } from 'src/app/core/services/snackbar.service';
+import { EmailService } from '../../services/email.service';
+import { DropdownModule } from 'primeng/dropdown';
+import { CenterService } from '../../services/center.service';
+import { CalendarModule } from 'primeng/calendar';
+
+@Component({
+  selector: 'app-evidence-email',
+  templateUrl: './evidence-email.component.html',
+  styleUrls: ['./evidence-email.component.scss']
+})
+export class EvidenceEmailComponent implements OnInit {
+
+  centers: Center[];
+
+  closingDate: Date;
+  center: Center;
+  isLoading: boolean;
+
+  constructor(
+    public emailService: EmailService,
+    public centerService: CenterService,
+    public dialogRef: DynamicDialogRef,
+    public config: DynamicDialogConfig,
+    private snackbarService: SnackbarService
+  ) { }
+
+  ngOnInit(): void {
+    this.isLoading = true;
+    this.centerService.getCenters().subscribe({
+     next:  centers => {
+        this.centers = centers;
+        this.isLoading = false;
+      },
+      error: error => {
+        this.snackbarService.error("Error obteniendo lista de centros. " + error);
+        this.isLoading = false;
+      }
+    }
+    );
+  }
+
+  onSend() {
+    this.isLoading = true;
+    this.emailService.sendEmails(this.closingDate, this.center.id).subscribe({
+      next: result => {
+        if (result)
+          this.snackbarService.showMessage("Recordatorios enviados. " + result);
+        else
+          this.snackbarService.showMessage("Recordatorios enviados.");
+        this.isLoading = false;
+        this.close();
+      },
+      error: error => {
+        this.snackbarService.error(error);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  /**
+    * En caso de cancelar el proceso, cerrar el diálogo.
+    */
+  onCancel() {
+    this.close();
+  }
+
+  /**
+   * Cerrar diálogo.
+   */
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/evidences/views/evidence-list/evidence-list.component.html
+++ b/src/app/evidences/views/evidence-list/evidence-list.component.html
@@ -1,2 +1,5 @@
 <p-toast position="top-center"></p-toast>
-<button #b pButton type="button" (click)="importarDatos()">Importar datos</button>
+<div class="flex gap-3">
+    <button #b pButton type="button" (click)="importarDatos()">Importar datos</button>
+    <button #b pButton type="button" (click)="evidenceEmails()">Notificar pendientes</button>
+</div>

--- a/src/app/evidences/views/evidence-list/evidence-list.component.ts
+++ b/src/app/evidences/views/evidence-list/evidence-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DialogService } from 'primeng/dynamicdialog';
+import { EvidenceEmailComponent } from '../evidence-email/evidence-email.component';
 import { EvidenceUploadComponent } from '../evidence-upload/evidence-upload.component';
 
 /**
@@ -32,6 +33,11 @@ export class EvidenceListComponent implements OnInit {
    */
   importarDatos(): void {
     const dialogRef = this.dialogService.open(EvidenceUploadComponent, { header: "Importar datos de GTE", width: "50%", closable: false });
+  }
+
+  /** TODO DOCS */
+  evidenceEmails(): void {
+    const dialogRef = this.dialogService.open(EvidenceEmailComponent, { header: "Notificar evidencias pendientes", width: "50%", closable: false });
   }
 
 }

--- a/src/app/evidences/views/evidence-list/evidence-list.component.ts
+++ b/src/app/evidences/views/evidence-list/evidence-list.component.ts
@@ -35,9 +35,13 @@ export class EvidenceListComponent implements OnInit {
     const dialogRef = this.dialogService.open(EvidenceUploadComponent, { header: "Importar datos de GTE", width: "50%", closable: false });
   }
 
-  /** TODO DOCS */
+  /**
+   * Inicia componente EvidenceEmail tras pulsar botón de envío de recordatorios.
+   * 
+   * Se ajusta título del diálogo y anchura al 25% del espacio disponible.
+   */
   evidenceEmails(): void {
-    const dialogRef = this.dialogService.open(EvidenceEmailComponent, { header: "Notificar evidencias pendientes", width: "50%", closable: false });
+    const dialogRef = this.dialogService.open(EvidenceEmailComponent, { header: "Notificar evidencias pendientes", width: "25%", closable: false });
   }
 
 }

--- a/src/app/evidences/views/evidence-upload/evidence-upload.component.spec.ts
+++ b/src/app/evidences/views/evidence-upload/evidence-upload.component.spec.ts
@@ -14,6 +14,7 @@ import { MessageModule } from 'primeng/message';
 import { MessagesModule } from 'primeng/messages';
 import { ToastModule } from 'primeng/toast';
 import { of } from 'rxjs';
+import { SnackbarService } from 'src/app/core/services/snackbar.service';
 import { environment } from 'src/environments/environment';
 import { EvidenceService } from '../../services/evidence.service';
 
@@ -38,14 +39,13 @@ describe('EvidenceUploadComponent', () => {
         DynamicDialogModule,
         CheckboxModule,
         FormsModule,
-        MessagesModule,
-        MessageModule,
         ToastModule
       ],
       providers: [
         EvidenceService,
         DynamicDialogRef,
         DynamicDialogConfig,
+        SnackbarService,
         MessageService
       ]
     })

--- a/src/app/evidences/views/evidence-upload/evidence-upload.component.spec.ts
+++ b/src/app/evidences/views/evidence-upload/evidence-upload.component.spec.ts
@@ -10,8 +10,6 @@ import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DynamicDialogConfig, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { FileUploadModule } from 'primeng/fileupload';
-import { MessageModule } from 'primeng/message';
-import { MessagesModule } from 'primeng/messages';
 import { ToastModule } from 'primeng/toast';
 import { of } from 'rxjs';
 import { SnackbarService } from 'src/app/core/services/snackbar.service';

--- a/src/app/evidences/views/evidence-upload/evidence-upload.component.ts
+++ b/src/app/evidences/views/evidence-upload/evidence-upload.component.ts
@@ -76,7 +76,7 @@ export class EvidenceUploadComponent implements OnInit {
                 if (result)
                     this.snackbarService.showMessage("Archivo subido correctamente. " + result);
                 else
-                    this.snackbarService.showMessage("Archivo subido correctamente. ");
+                    this.snackbarService.showMessage("Archivo subido correctamente.");
                 this.isLoading = false;
                 this.close();
             },


### PR DESCRIPTION
Implementación frontend del caso de uso GM-07: Envío de correos para GTE Manager.
Interfaz frontend con diálogo adicional para selección de geografía y fecha de cierre, y envío de parámetros para correos electrónicos recordatorios según centro seleccionado. Se muestran mensajes de error y de confirmación en pantalla, además de una animación de carga.

Objetos:
- Center: objeto para datos de centros.
- Reminder: objeto para transmisión de fecha de cierre e ID de centro a backend.

Componentes:
- EvidenceEmail: diálogo para selección de geografía y fecha de cierre.
	
Servicios:
- EmailService: servicio de datos para comunicación con backend a través de método POST.
- CenterService: servicio de datos para obtención de centros con backend a través de método GET.

Se incluyen 15 tests de prueba para los elementos del módulo Evidences. Los tests de estos elementos resultan OK.
