### PR TITLE
Solucionar offset de fecha por zonas horarias

### DIFF
--- a/src/app/evidences/views/evidence-email/evidence-email.component.ts
+++ b/src/app/evidences/views/evidence-email/evidence-email.component.ts
@@ -69,7 +69,7 @@ export class EvidenceEmailComponent implements OnInit {
     this.isLoading = true;
 
     let reminder = new Reminder();
-    reminder.closingDate = this.closingDate;
+    reminder.closingDate = new Date(Date.UTC(this.closingDate.getFullYear(), this.closingDate.getMonth(), this.closingDate.getDate()));
     reminder.centerId = this.center.id;
 
     this.emailService.sendEmails(reminder).subscribe({


### PR DESCRIPTION
Ajustar closingDate para obtener fecha en formato correcto, y evitar que llegue a backend con un offset por la zona horaria (podría resultar en que backend recibe una fecha con un día de menos o de más).